### PR TITLE
Preparing for additional meta information fill-up and `preload=False` argument support to mne.io.RawANT

### DIFF
--- a/src/antio/libeep/__init__.py
+++ b/src/antio/libeep/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date, datetime, timezone
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -11,6 +11,7 @@ from . import pyeep
 
 if TYPE_CHECKING:
     from collections.abc import ByteString
+    from datetime import date
     from typing import Optional, Union
 
     from numpy.typing import NDArray

--- a/src/antio/libeep/__init__.py
+++ b/src/antio/libeep/__init__.py
@@ -167,41 +167,31 @@ class InputCNT(BaseCNT):
         """
         return pyeep.get_samples_as_buffer(self._handle, fro, to)
 
-    def _get_start_time(self):
-        """Get start time in UNIX format.
+    def get_start_time(self) -> datetime:
+        """Get start time.
 
         Returns
         -------
-        start_time : int
+        start_time : datetime
             Acquisition start time.
         """
-        return pyeep.get_start_time(self._handle)
+        start_time = pyeep.get_start_time(self._handle)
+        return datetime.fromtimestamp(start_time, timezone.utc)
 
-    def _get_start_time(self):
-        """Get start time in UNIX format.
+    def get_start_time_and_fraction(self) -> Optional[datetime]:
+        """Get start time with second fraction.
 
         Returns
         -------
-        start_time : float
-            Acquisition start time.
+        start_time : datetime | None
+            The measurement time of the recording (in the UTC timezone). None if the
+            start date parsed was not a valid EXCEL format start date.
         """
         start_date, start_fraction = pyeep.get_start_date_and_fraction(self._handle)
         # start date is in EXCEL format
         if start_date >= 27538 and start_date <= 2958464:
             start_date = np.round(start_date * 3600.0 * 24.0) - 2209161600
-        else:
-            start_date = 0
-        return start_date + start_fraction
-
-    def get_start_time(self) -> datetime:
-        """Get start time in datetime format.
-
-        Returns
-        -------
-        start_time : datetime.datetime
-            Acquisition start time.
-        """
-        return datetime.fromtimestamp(self._get_start_time(), timezone.utc)
+            return datetime.fromtimestamp(start_date + start_fraction, timezone.utc)
 
     def get_hospital(self) -> str:
         """Get hospital name of the recording.

--- a/src/antio/libeep/__init__.py
+++ b/src/antio/libeep/__init__.py
@@ -258,9 +258,7 @@ class InputCNT(BaseCNT):
             date of birth in datetime format.
         """
         year, month, day = pyeep.get_date_of_birth(self._handle)
-        return datetime(
-            year=year, month=month, day=day, tzinfo=timezone.utc
-            ).date()
+        return datetime(year=year, month=month, day=day, tzinfo=timezone.utc).date()
 
     def get_trigger_count(self) -> int:
         """Get the total number of triggers (annotations).

--- a/src/antio/libeep/__init__.py
+++ b/src/antio/libeep/__init__.py
@@ -176,6 +176,22 @@ class InputCNT(BaseCNT):
         """
         return pyeep.get_start_time(self._handle)
 
+    def _get_start_time(self):
+        """Get start time in UNIX format.
+
+        Returns
+        -------
+        start_time : float
+            Acquisition start time.
+        """
+        start_date, start_fraction = pyeep.get_start_date_and_fraction(self._handle)
+        # start date is in EXCEL format
+        if start_date >= 27538 and start_date <= 2958464:
+            start_date = np.round(start_date * 3600.0 * 24.0) - 2209161600
+        else:
+            start_date = 0
+        return start_date + start_fraction
+
     def get_start_time(self) -> datetime:
         """Get start time in datetime format.
 

--- a/src/antio/libeep/__init__.py
+++ b/src/antio/libeep/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -233,7 +233,7 @@ class InputCNT(BaseCNT):
             self._get_date_of_birth(),
         )
 
-    def _get_date_of_birth(self) -> datetime:
+    def _get_date_of_birth(self) -> date:
         """Get date of birth of the patient.
 
         Returns
@@ -242,7 +242,9 @@ class InputCNT(BaseCNT):
             date of birth in datetime format.
         """
         year, month, day = pyeep.get_date_of_birth(self._handle)
-        return datetime(year=year, month=month, day=day, tzinfo=timezone.utc)
+        return datetime(
+            year=year, month=month, day=day, tzinfo=timezone.utc
+            ).date()
 
     def get_trigger_count(self) -> int:
         """Get the total number of triggers (annotations).

--- a/src/antio/parser.py
+++ b/src/antio/parser.py
@@ -118,10 +118,10 @@ def read_data(
     ----------
     cnt : InputCNT
         The cnt object from which the data is read.
-        first_samp : int
-            Start index.
-        last_samp : int
-            End index.
+    first_samp : int
+        Start index.
+    last_samp : int
+        End index.
 
     Returns
     -------

--- a/src/antio/parser.py
+++ b/src/antio/parser.py
@@ -122,9 +122,9 @@ def read_data(
     ----------
     cnt : InputCNT
         The cnt object from which the data is read.
-        fro : int
+        first_samp : int
             Start index.
-        to : int
+        n_samples : int
             End index.
 
     Returns
@@ -137,8 +137,10 @@ def read_data(
     The type casting makes the output array writeable.
     """
     if n_samples is None:
-        n_samples = cnt.get_sample_count()  # sample = (n_channels,)
-    return cnt.get_samples_as_nparray(first_samp, n_samples).astype("float64")
+        n_samples = cnt.get_sample_count() - first_samp  # sample = (n_channels,)
+    return cnt.get_samples_as_nparray(
+        first_samp, first_samp + n_samples
+        ).astype("float64")
 
 
 def read_triggers(cnt: InputCNT) -> tuple[list, list, list, list, dict[str, list[int]]]:

--- a/src/antio/parser.py
+++ b/src/antio/parser.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 if TYPE_CHECKING:
+    from typing import Optional
+
     from numpy.typing import NDArray
 
     from .libeep import InputCNT
@@ -45,8 +47,8 @@ def read_info(
     return ch_names, ch_units, ch_refs, ch_status, ch_types
 
 
-def read_subject_info(cnt: InputCNT) -> list[str, str, int, datetime.date]:
-    """Parse the channel information from the cnt file.
+def read_subject_info(cnt: InputCNT) -> tuple[str, str, int, datetime.date]:
+    """Parse the subject information from the cnt file.
 
     Parameters
     ----------
@@ -57,7 +59,7 @@ def read_subject_info(cnt: InputCNT) -> list[str, str, int, datetime.date]:
     -------
     his_id : str
         String subject identifier.
-    name: list of str
+    name : str
         Name.
     sex : int
         Subject sex (0=unknown, 1=male, 2=female).
@@ -69,7 +71,7 @@ def read_subject_info(cnt: InputCNT) -> list[str, str, int, datetime.date]:
     return his_id, name, sex, birthday
 
 
-def read_device_info(cnt: InputCNT) -> list[str, str, str, str]:
+def read_device_info(cnt: InputCNT) -> tuple[str, str, str, str]:
     """Parse the machine information from the cnt file.
 
     Parameters
@@ -110,7 +112,7 @@ def read_meas_date(cnt: InputCNT) -> datetime.datetime:
 
 
 def read_data(
-    cnt: InputCNT, first_samp: int = 0, last_samp: int | None = None
+    cnt: InputCNT, first_samp: int = 0, last_samp: Optional[int] = None
 ) -> NDArray[np.float64]:
     """Read the data array.
 

--- a/src/antio/parser.py
+++ b/src/antio/parser.py
@@ -45,7 +45,6 @@ def read_info(
     return ch_names, ch_units, ch_refs, ch_status, ch_types
 
 
-def read_data(cnt: InputCNT) -> NDArray[np.float64]:
 def read_subject_info(
         cnt: InputCNT
         ) -> list[str, str, int, datetime.date]:
@@ -114,12 +113,19 @@ def read_meas_date(cnt: InputCNT) -> datetime.datetime:
     return cnt.get_start_time()
 
 
+def read_data(
+        cnt: InputCNT, first_samp: int = 0, n_samples: int | None = None
+        ) -> NDArray[np.float64]:
     """Read the data array.
 
     Parameters
     ----------
     cnt : InputCNT
         The cnt object from which the data is read.
+        fro : int
+            Start index.
+        to : int
+            End index.
 
     Returns
     -------
@@ -130,8 +136,9 @@ def read_meas_date(cnt: InputCNT) -> datetime.datetime:
     -----
     The type casting makes the output array writeable.
     """
-    n_samples = cnt.get_sample_count()  # sample = (n_channels,)
-    return cnt.get_samples_as_nparray(0, n_samples).astype(np.float64)
+    if n_samples is None:
+        n_samples = cnt.get_sample_count()  # sample = (n_channels,)
+    return cnt.get_samples_as_nparray(first_samp, n_samples).astype("float64")
 
 
 def read_triggers(cnt: InputCNT) -> tuple[list, list, list, list, dict[str, list[int]]]:

--- a/src/antio/parser.py
+++ b/src/antio/parser.py
@@ -45,9 +45,7 @@ def read_info(
     return ch_names, ch_units, ch_refs, ch_status, ch_types
 
 
-def read_subject_info(
-        cnt: InputCNT
-        ) -> list[str, str, int, datetime.date]:
+def read_subject_info(cnt: InputCNT) -> list[str, str, int, datetime.date]:
     """Parse the channel information from the cnt file.
 
     Parameters
@@ -71,9 +69,7 @@ def read_subject_info(
     return his_id, name, sex, birthday
 
 
-def read_device_info(
-        cnt: InputCNT
-        ) -> list[str, str, str, str]:
+def read_device_info(cnt: InputCNT) -> list[str, str, str, str]:
     """Parse the machine information from the cnt file.
 
     Parameters
@@ -114,8 +110,8 @@ def read_meas_date(cnt: InputCNT) -> datetime.datetime:
 
 
 def read_data(
-        cnt: InputCNT, first_samp: int = 0, last_samp: int | None = None
-        ) -> NDArray[np.float64]:
+    cnt: InputCNT, first_samp: int = 0, last_samp: int | None = None
+) -> NDArray[np.float64]:
     """Read the data array.
 
     Parameters
@@ -138,9 +134,7 @@ def read_data(
     """
     if last_samp is None:
         last_samp = cnt.get_sample_count()  # sample = (n_channels,)
-    return cnt.get_samples_as_nparray(
-        first_samp, last_samp
-        ).astype("float64")
+    return cnt.get_samples_as_nparray(first_samp, last_samp).astype("float64")
 
 
 def read_triggers(cnt: InputCNT) -> tuple[list, list, list, list, dict[str, list[int]]]:

--- a/src/antio/parser.py
+++ b/src/antio/parser.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -45,6 +46,74 @@ def read_info(
 
 
 def read_data(cnt: InputCNT) -> NDArray[np.float64]:
+def read_subject_info(
+        cnt: InputCNT
+        ) -> list[str, str, int, datetime.date]:
+    """Parse the channel information from the cnt file.
+
+    Parameters
+    ----------
+    cnt : InputCNT
+        The cnt object from which the information is read.
+
+    Returns
+    -------
+    his_id : str
+        String subject identifier.
+    name: list of str
+        Name.
+    sex : int
+        Subject sex (0=unknown, 1=male, 2=female).
+    birthday : datetime.date
+        The subject birthday.
+    """
+    name, his_id, sex, birthday = cnt.get_patient_info()
+    sex = {"": 0, "M": 1, "F": 2}[sex]
+    return his_id, name, sex, birthday
+
+
+def read_device_info(
+        cnt: InputCNT
+        ) -> list[str, str, str, str]:
+    """Parse the machine information from the cnt file.
+
+    Parameters
+    ----------
+    cnt : InputCNT
+        The cnt object from which the information is read.
+
+    Returns
+    -------
+    make : str
+        Device type.
+    model : str
+        Device model.
+    serial : str
+        Device serial.
+    site : str
+        Device site.
+    """
+    make, mode, serial = cnt.get_machine_info()
+    site = cnt.get_hospital()
+    return make, mode, serial, site
+
+
+def read_meas_date(cnt: InputCNT) -> datetime.datetime:
+    """Parse the measurement from the cnt file.
+
+    Parameters
+    ----------
+    cnt : InputCNT
+        The cnt object from which the information is read.
+
+    Returns
+    -------
+    meas_date : datetime
+        The time (UTC) of the recording.
+    """
+    return cnt.get_start_time()
+
+
     """Read the data array.
 
     Parameters

--- a/src/antio/parser.py
+++ b/src/antio/parser.py
@@ -114,7 +114,7 @@ def read_meas_date(cnt: InputCNT) -> datetime.datetime:
 
 
 def read_data(
-        cnt: InputCNT, first_samp: int = 0, n_samples: int | None = None
+        cnt: InputCNT, first_samp: int = 0, last_samp: int | None = None
         ) -> NDArray[np.float64]:
     """Read the data array.
 
@@ -124,7 +124,7 @@ def read_data(
         The cnt object from which the data is read.
         first_samp : int
             Start index.
-        n_samples : int
+        last_samp : int
             End index.
 
     Returns
@@ -136,10 +136,10 @@ def read_data(
     -----
     The type casting makes the output array writeable.
     """
-    if n_samples is None:
-        n_samples = cnt.get_sample_count() - first_samp  # sample = (n_channels,)
+    if last_samp is None:
+        last_samp = cnt.get_sample_count()  # sample = (n_channels,)
     return cnt.get_samples_as_nparray(
-        first_samp, first_samp + n_samples
+        first_samp, last_samp
         ).astype("float64")
 
 

--- a/src/antio/parser.py
+++ b/src/antio/parser.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import datetime
 from typing import TYPE_CHECKING
 
 import numpy as np
 
 if TYPE_CHECKING:
+    from datetime import date, datetime
     from typing import Optional
 
     from numpy.typing import NDArray
@@ -47,7 +47,7 @@ def read_info(
     return ch_names, ch_units, ch_refs, ch_status, ch_types
 
 
-def read_subject_info(cnt: InputCNT) -> tuple[str, str, int, datetime.date]:
+def read_subject_info(cnt: InputCNT) -> tuple[str, str, int, date]:
     """Parse the subject information from the cnt file.
 
     Parameters
@@ -95,7 +95,7 @@ def read_device_info(cnt: InputCNT) -> tuple[str, str, str, str]:
     return make, mode, serial, site
 
 
-def read_meas_date(cnt: InputCNT) -> datetime.datetime:
+def read_meas_date(cnt: InputCNT) -> Optional[datetime]:
     """Parse the measurement from the cnt file.
 
     Parameters
@@ -105,10 +105,10 @@ def read_meas_date(cnt: InputCNT) -> datetime.datetime:
 
     Returns
     -------
-    meas_date : datetime
-        The time (UTC) of the recording.
+    meas_date : datetime | None
+        The measurement time of the recording (in the UTC timezone).
     """
-    return cnt.get_start_time()
+    return cnt.get_start_time_and_fraction()
 
 
 def read_data(

--- a/src/libeep/python/pyeep.c
+++ b/src/libeep/python/pyeep.c
@@ -295,6 +295,20 @@ pyeep_get_start_time(PyObject* self, PyObject* args) {
 ///////////////////////////////////////////////////////////////////////////////
 static
 PyObject *
+pyeep_get_start_date_and_fraction(PyObject* self, PyObject* args) {
+  int handle;
+  double start_date;
+  double start_fraction;
+
+  if(!PyArg_ParseTuple(args, "i", & handle)) {
+    return NULL;
+  }
+  libeep_get_start_date_and_fraction(handle, &start_date, &start_fraction);
+  return Py_BuildValue("dd", start_date, start_fraction);
+}
+///////////////////////////////////////////////////////////////////////////////
+static
+PyObject *
 pyeep_get_hospital(PyObject* self, PyObject* args) {
   int handle;
 
@@ -455,8 +469,8 @@ static PyMethodDef methods[] = {
 // void libeep_free_raw_samples(int32_t *data);
 // recinfo_t libeep_create_recinfo();
 // void libeep_add_recording_info(cntfile_t cnt_handle, recinfo_t recinfo_handle);
-  {"get_start_time",           pyeep_get_start_time,           METH_VARARGS, "get start time"},
-// void libeep_get_start_date_and_fraction(recinfo_t handle, double* start_date, double* start_fraction);
+  {"get_start_time",           pyeep_get_start_time,           METH_VARARGS, "get start time in UNIX format"},
+  {"get_start_date_and_fraction",     pyeep_get_start_date_and_fraction,    METH_VARARGS, "get start date and fraction in EXCEL format"},
 // void libeep_set_start_time(recinfo_t handle, time_t start_time);
 // void libeep_set_start_date_and_fraction(recinfo_t handle, double start_date, double start_fraction);
   {"get_hospital",            pyeep_get_hospital,              METH_VARARGS, "get hospital"},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,11 +36,12 @@ def ca_208() -> dict[str, Union[dict[str, Path], str, int]]:
         "patient_info": {
             "name": "antio test",
             "id": "",
-            "birthday": "2024-08-14+0000",
+            "birthday": "2024-08-14",
             "sex": "",
         },
         # TODO: Investigate why the serial number is missing.
         "machine_info": ("eego", "EE_225", ""),
+        "hospital": "",
     }
 
 
@@ -64,11 +65,12 @@ def andy_101() -> dict[str, Union[dict[str, Path], str, int]]:
         "patient_info": {
             "name": "Andy test_middle_name EEG_Exam",
             "id": "test_subject_code",
-            "birthday": "2024-08-19+0000",
+            "birthday": "2024-08-19",
             "sex": "F",
         },
         # TODO: Investigate why the serial number is missing.
         "machine_info": ("eego", "EE_226", ""),
+        "hospital": "",
     }
 
 

--- a/tests/libeep/test_libeep.py
+++ b/tests/libeep/test_libeep.py
@@ -61,6 +61,10 @@ def test_read_meas_date(dataset, meas_date_format, request):
     start_time = cnt.get_start_time()
     assert isinstance(start_time, datetime)
     assert start_time.strftime(meas_date_format) == dataset["meas_date"]
+    start_time_fraction = cnt.get_start_time_and_fraction()
+    assert isinstance(start_time_fraction, datetime)
+    assert start_time_fraction.strftime(meas_date_format) == dataset["meas_date"]
+    assert start_time != start_time_fraction
 
 
 @pytest.mark.parametrize("dataset", ["andy_101", "ca_208"])

--- a/tests/libeep/test_libeep.py
+++ b/tests/libeep/test_libeep.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from itertools import product
 
 import numpy as np
@@ -135,7 +135,8 @@ def test_get_patient_information(dataset, birthday_format, request):
     name, patient_id, sex, birthday = cnt.get_patient_info()
     assert name == dataset["patient_info"]["name"]
     assert patient_id == dataset["patient_info"]["id"]
-    assert isinstance(birthday, datetime)
+    assert sex == dataset["patient_info"]["sex"]
+    assert isinstance(birthday, date)
     assert birthday.strftime(birthday_format) == dataset["patient_info"]["birthday"]
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -5,7 +5,14 @@ import pytest
 from numpy.testing import assert_allclose
 
 from antio import read_cnt
-from antio.parser import read_data, read_info, read_triggers
+from antio.parser import (
+    read_data,
+    read_device_info,
+    read_info,
+    read_meas_date,
+    read_subject_info,
+    read_triggers,
+)
 
 
 @pytest.mark.parametrize("dataset", ["andy_101", "ca_208"])
@@ -29,6 +36,37 @@ def test_read_info(dataset, read_raw_bv, request):
 def test_read_info_status_types():
     """Test parsing channel status and types."""
     # TODO: Placeholder for when we have a test file with channel status and types
+
+
+@pytest.mark.parametrize("dataset", ["andy_101", "ca_208"])
+def test_read_subject_info(dataset, birthday_format, request):
+    """Test reading the data array."""
+    dataset = request.getfixturevalue(dataset)
+    cnt = read_cnt(dataset["cnt"]["short"])
+    his_id, name, sex, birthday = read_subject_info(cnt)
+    assert his_id == dataset["patient_info"]["id"]
+    assert name == dataset["patient_info"]["name"]
+    assert ("", "M", "F")[sex] == dataset["patient_info"]["sex"]
+    assert birthday.strftime(birthday_format) == dataset["patient_info"]["birthday"]
+
+
+@pytest.mark.parametrize("dataset", ["andy_101", "ca_208"])
+def test_read_device_info(dataset, request):
+    """Test reading the data array."""
+    dataset = request.getfixturevalue(dataset)
+    cnt = read_cnt(dataset["cnt"]["short"])
+    *machine_info, site = read_device_info(cnt)
+    assert tuple(machine_info) == dataset["machine_info"]
+    assert site == dataset["hospital"]
+
+
+@pytest.mark.parametrize("dataset", ["andy_101", "ca_208"])
+def test_read_meas_date(dataset, meas_date_format, request):
+    """Test reading the data array."""
+    dataset = request.getfixturevalue(dataset)
+    cnt = read_cnt(dataset["cnt"]["short"])
+    meas_date = read_meas_date(cnt)
+    assert meas_date.strftime(meas_date_format) == dataset["meas_date"]
 
 
 @pytest.mark.parametrize("dataset", ["andy_101", "ca_208"])


### PR DESCRIPTION
This is a follow up to `ADD python wrappers for pt/machine/recording info`. The parser exposes the wrappers to MNE. Also, this pull request add functionality to enable `_read_segment_file()` method for RawANT object, so that `preload=False` can be realized.

[ENH]
- prepare read_data() for adding _read_segment_file
- make start time reading more precise (in milliseconds)
- add additional meta information readers in parser
  -  read_subject_info()
  -  read_device_info()
  -  read_meas_date()

[FIX]
-  change birthday format (datetime -> date)