### PR TITLE
Update for python 3.9 to 3.13

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,7 +73,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
-        python: ["3.9", "3.12"]
+        python: ["3.9", "3.13"]
     name: test wheels on ${{ matrix.os }} - py${{ matrix.python }}
     runs-on: ${{ matrix.os }}
     defaults:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
   'Programming Language :: Python :: 3.10',
   'Programming Language :: Python :: 3.11',
   'Programming Language :: Python :: 3.12',
+  'Programming Language :: Python :: 3.13',
   'Programming Language :: Python :: 3.9',
 ]
 dependencies = [
@@ -75,7 +76,7 @@ tracker = 'https://github.com/mscheltienne/antio/issues'
 
 [tool.cibuildwheel]
 archs = "native"
-build = "cp312-*"
+build = "cp313-*"
 skip = "*musllinux*"
 test-command = "pytest {project}/tests"
 test-extras = ["test"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ tracker = 'https://github.com/mscheltienne/antio/issues'
 
 [tool.cibuildwheel]
 archs = "native"
-build = "cp313-*"
+build = "cp312-*"
 skip = "*musllinux*"
 test-command = "pytest {project}/tests"
 test-extras = ["test"]


### PR DESCRIPTION
Reminder for python 3.13.
Let's wait for python 3.13 stable release, then addition to `cibuildwheel` (already supports the `rc`), then cut a release with support from 3.9 to 3.13 which becomes the minimum supported version in MNE. And then we are done until bug reports come in ;)
Note: the required tests will have to be updated.