### PR TITLE
MAINT: Allow editable installs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,7 +144,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - run: pip install -ve .
+      - run: pip install -ve .[test]
       - run: antio sys-info --developer
       - run: pytest tests/ --cov=antio --cov-report=xml
       - uses: codecov/codecov-action@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,6 +135,22 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  editable:
+    timeout-minutes: 10
+    name: test editable install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install -ve .
+      - run: antio sys-info --developer
+      - run: pytest tests/ --cov=antio --cov-report=xml
+      - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   sdist:
     timeout-minutes: 10
     name: create sdist

--- a/.gitignore
+++ b/.gitignore
@@ -126,7 +126,7 @@ dmypy.json
 
 # cibuildwheels
 wheelhouse/
-antio/libeep/*.dll
-antio/libeep/*.so
-antio/libeep/*.dylib
-antio/libeep/*.pyd
+src/antio/libeep/*.dll
+src/antio/libeep/*.so
+src/antio/libeep/*.dylib
+src/antio/libeep/*.pyd

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,8 @@ else:
 
 
 class CMakeExtension(Extension):
+    """Dummy wrapper for CMake build."""
+
     def __init__(self, name, py_limited_api=False):
         # don't invoke the original build_ext for this special extension
         super().__init__(name, sources=[], py_limited_api=py_limited_api)
@@ -78,7 +80,7 @@ class build_ext(_build_ext):  # noqa: D101
             for elt in (lib, pyeep):
                 dst = Path(self.build_lib) / "antio" / "libeep" / elt.name
                 dst.parent.mkdir(parents=True, exist_ok=True)
-                print(f"Moving {elt} to {dst}")
+                print(f"Moving {elt} to {dst}")  # noqa: T201
                 shutil.move(elt, dst)
         super().run()
 

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 import os
 import platform
 import pprint
+import shutil
 import subprocess
 import sys
 from pathlib import Path
-import shutil
 from tempfile import TemporaryDirectory
 
 from setuptools import setup
@@ -24,7 +24,6 @@ else:
 
 
 class CMakeExtension(Extension):
-
     def __init__(self, name, py_limited_api=False):
         # don't invoke the original build_ext for this special extension
         super().__init__(name, sources=[], py_limited_api=py_limited_api)

--- a/src/antio/utils/config.py
+++ b/src/antio/utils/config.py
@@ -9,8 +9,6 @@ from typing import TYPE_CHECKING
 import psutil
 from packaging.requirements import Requirement
 
-from ..libeep import pyeep
-
 if TYPE_CHECKING:
     from typing import IO, Callable, Optional
 
@@ -26,6 +24,8 @@ def sys_info(fid: Optional[IO] = None, developer: bool = False):
     developer : bool
         If True, display information about optional dependencies.
     """
+    from ..libeep import pyeep
+
     developer = bool(developer)
     ljust = 26
     out = partial(print, end="", file=fid)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,18 +1,12 @@
 from __future__ import annotations
 
 import warnings
+from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import Optional, Union
 
 import pytest
-from mne.io import read_raw_brainvision
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
-    from typing import Optional, Union
-
-    from mne.io import BaseRaw
-
+from mne.io import BaseRaw, read_raw_brainvision
 
 TypeDataset = dict[
     str,


### PR DESCRIPTION
I was surprised `pip install --no-build-isolation -ve .` didn't work because this is how I install everything in my dev env nowadays. This PR should make it work. Works on my machine :tm: To make sure it continues to work I added a CI run for it.

The "trick" is to subclass `Extension` as `CMakeExtension` which is a no-op, then use `ext_modules` as usual rather than `distclass`. This causes setuptools to properly recognize that there is an extension being built that it should include in the right place.

Also had to nest one import to avoid a circular import problem, no idea why it's not present on `main` but shouldn't hurt anything :shrug: 