### PR TITLE
Improve support of different encoding formats

### DIFF
--- a/src/antio/libeep/__init__.py
+++ b/src/antio/libeep/__init__.py
@@ -46,7 +46,9 @@ class InputCNT(BaseCNT):
         """
         return pyeep.get_channel_count(self._handle)
 
-    def get_channel(self, index: int, encoding: str) -> tuple[str, str, str, str, str]:
+    def get_channel(
+        self, index: int, *, encoding: str
+    ) -> tuple[str, str, str, str, str]:
         """Get the channel information at a given index.
 
         Parameters
@@ -200,17 +202,20 @@ class InputCNT(BaseCNT):
             start_date = np.round(start_date * 3600.0 * 24.0) - 2209161600
             return datetime.fromtimestamp(start_date + start_fraction, timezone.utc)
 
-    def get_hospital(self) -> str:
+    def get_hospital(self, *, encoding: str) -> str:
         """Get hospital name of the recording.
 
         Returns
         -------
         hospital : str
             Hospital name.
+        encoding : str
+            Encoding used for the string.
         """
-        return pyeep.get_hospital(self._handle)
+        hospital = pyeep.get_hospital(self._handle)
+        return hospital.decode(encoding) if hospital is not None else ""
 
-    def get_machine_info(self) -> tuple[str, str, str]:
+    def get_machine_info(self, *, encoding: str) -> tuple[str, str, str]:
         """Get machine information.
 
         Returns
@@ -220,12 +225,19 @@ class InputCNT(BaseCNT):
             - 0: machine make
             - 1: machine model
             - 2: machine serial number
+        encoding : str
+            Encoding used for the strings.
         """
-        return (
-            pyeep.get_machine_make(self._handle),
-            pyeep.get_machine_model(self._handle),
-            pyeep.get_machine_serial_number(self._handle),
+        functions = (
+            pyeep.get_machine_make,
+            pyeep.get_machine_model,
+            pyeep.get_machine_serial_number,
         )
+        info = []
+        for func in functions:
+            value = func(self._handle)
+            info.append(value.decode(encoding) if value is not None else "")
+        return tuple(info)
 
     def get_patient_info(self) -> tuple[str, str, str, date | None]:
         """Get patient info.

--- a/src/antio/libeep/__init__.py
+++ b/src/antio/libeep/__init__.py
@@ -239,7 +239,7 @@ class InputCNT(BaseCNT):
             info.append(value.decode(encoding) if value is not None else "")
         return tuple(info)
 
-    def get_patient_info(self) -> tuple[str, str, str, date | None]:
+    def get_patient_info(self, *, encoding: str) -> tuple[str, str, str, date | None]:
         """Get patient info.
 
         Returns
@@ -250,14 +250,18 @@ class InputCNT(BaseCNT):
             - 1: patient id
             - 2: patient sex
             - 3: patient date of birth
+        encoding : str
+            Encoding used for the strings.
         """
+        functions = (pyeep.get_patient_name, pyeep.get_patient_id)
+        info = []
+        for func in functions:
+            value = func(self._handle)
+            info.append(value.decode(encoding) if value is not None else "")
         sex = pyeep.get_patient_sex(self._handle)
-        return (
-            pyeep.get_patient_name(self._handle),
-            pyeep.get_patient_id(self._handle),
-            "" if sex == "\x00" else sex,
-            self._get_date_of_birth(),
-        )
+        info.append("" if sex == "\x00" else sex)
+        info.append(self._get_date_of_birth())
+        return tuple(info)
 
     def _get_date_of_birth(self) -> date:
         """Get date of birth of the patient.

--- a/src/antio/libeep/__init__.py
+++ b/src/antio/libeep/__init__.py
@@ -46,9 +46,7 @@ class InputCNT(BaseCNT):
         """
         return pyeep.get_channel_count(self._handle)
 
-    def get_channel(
-        self, index: int, encoding: str = "latin-1"
-    ) -> tuple[str, str, str, str, str]:
+    def get_channel(self, index: int, encoding: str) -> tuple[str, str, str, str, str]:
         """Get the channel information at a given index.
 
         Parameters
@@ -56,7 +54,7 @@ class InputCNT(BaseCNT):
         index : int
             Index of the channel.
         encoding : str
-            Encoding used for the unit string.
+            Encoding used for the strings.
 
         Returns
         -------

--- a/src/antio/libeep/__init__.py
+++ b/src/antio/libeep/__init__.py
@@ -75,15 +75,18 @@ class InputCNT(BaseCNT):
             raise RuntimeError(
                 f"Channel index {index} exceeds total channel count {n_channels}."
             )
-        unit = pyeep.get_channel_unit(self._handle, index)
-        unit = unit.decode(encoding) if unit is not None else ""
-        return (
-            pyeep.get_channel_label(self._handle, index),
-            unit,
-            pyeep.get_channel_reference(self._handle, index),
-            pyeep.get_channel_status(self._handle, index),
-            pyeep.get_channel_type(self._handle, index),
+        functions = (
+            pyeep.get_channel_label,
+            pyeep.get_channel_unit,
+            pyeep.get_channel_reference,
+            pyeep.get_channel_status,
+            pyeep.get_channel_type,
         )
+        channel = []
+        for func in functions:
+            value = func(self._handle, index)
+            channel.append(value.decode(encoding) if value is not None else "")
+        return tuple(channel)
 
     def get_sample_frequency(self) -> int:
         """Get the sampling frequency of the recording in Hz.

--- a/src/antio/parser.py
+++ b/src/antio/parser.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 
 def read_info(
-    cnt: InputCNT,
+    cnt: InputCNT, *, encoding: str = "latin-1"
 ) -> tuple[list[str], list[str], list[str], list[str], list[str]]:
     """Parse the channel information from the cnt file.
 
@@ -37,10 +37,13 @@ def read_info(
     ch_types : list of str
         List of channel types.
         .. versionadded: 0.3.0.
+    encoding : str
+        Encoding used for the strings.
+        .. versionadded: 0.5.0
     """
     ch_names, ch_units, ch_refs, ch_status, ch_types = [], [], [], [], []
     for k in range(cnt.get_channel_count()):
-        channel = cnt.get_channel(k)
+        channel = cnt.get_channel(k, encoding=encoding)
         ch_names.append(channel[0])
         ch_units.append(channel[1].lower())  # always lower the unit for mapping
         ch_refs.append(channel[2])

--- a/src/antio/parser.py
+++ b/src/antio/parser.py
@@ -80,7 +80,9 @@ def read_subject_info(cnt: InputCNT) -> tuple[str, str, int, date]:
     return his_id, name, sex, birthday
 
 
-def read_device_info(cnt: InputCNT) -> tuple[str, str, str, str]:
+def read_device_info(
+    cnt: InputCNT, *, encoding: str = "latin-1"
+) -> tuple[str, str, str, str]:
     """Parse the machine information from the cnt file.
 
     Parameters
@@ -98,13 +100,16 @@ def read_device_info(cnt: InputCNT) -> tuple[str, str, str, str]:
         Device serial.
     site : str
         Device site.
+    encoding : str
+        Encoding used for the strings.
+        .. versionadded: 0.5.0
 
     Notes
     -----
     .. versionadded: 0.3.0.
     """
-    make, mode, serial = cnt.get_machine_info()
-    site = cnt.get_hospital()
+    make, mode, serial = cnt.get_machine_info(encoding=encoding)
+    site = cnt.get_hospital(encoding=encoding)
     return make, mode, serial, site
 
 

--- a/src/antio/parser.py
+++ b/src/antio/parser.py
@@ -52,7 +52,9 @@ def read_info(
     return ch_names, ch_units, ch_refs, ch_status, ch_types
 
 
-def read_subject_info(cnt: InputCNT) -> tuple[str, str, int, date]:
+def read_subject_info(
+    cnt: InputCNT, *, encoding: str = "latin-1"
+) -> tuple[str, str, int, date]:
     """Parse the subject information from the cnt file.
 
     Parameters
@@ -70,12 +72,15 @@ def read_subject_info(cnt: InputCNT) -> tuple[str, str, int, date]:
         Subject sex (0=unknown, 1=male, 2=female).
     birthday : datetime.date | None
         The subject birthday. None if it could not be parsed.
+    encoding : str
+        Encoding used for the strings.
+        .. versionadded: 0.5.0
 
     Notes
     -----
     .. versionadded: 0.3.0.
     """
-    name, his_id, sex, birthday = cnt.get_patient_info()
+    name, his_id, sex, birthday = cnt.get_patient_info(encoding=encoding)
     sex = {"": 0, "M": 1, "F": 2}.get(sex, 0)
     return his_id, name, sex, birthday
 

--- a/src/libeep/python/pyeep.c
+++ b/src/libeep/python/pyeep.c
@@ -407,6 +407,13 @@ pyeep_get_patient_id(PyObject* self, PyObject* args) {
     return NULL;
   }
 
+  const char* patient_id_str = libeep_get_patient_id(handle);
+  if (patient_id_str == NULL) {
+      Py_RETURN_NONE;
+  }
+
+  return Py_BuildValue("y", patient_id_str);
+
   return Py_BuildValue("s", libeep_get_patient_id(handle));
 }
 ///////////////////////////////////////////////////////////////////////////////
@@ -419,7 +426,12 @@ pyeep_get_patient_name(PyObject* self, PyObject* args) {
     return NULL;
   }
 
-  return Py_BuildValue("s", libeep_get_patient_name(handle));
+  const char* patient_str = libeep_get_patient_name(handle);
+  if (patient_str == NULL) {
+      Py_RETURN_NONE;
+  }
+
+  return Py_BuildValue("y", patient_str);
 }
 ///////////////////////////////////////////////////////////////////////////////
 static

--- a/src/libeep/python/pyeep.c
+++ b/src/libeep/python/pyeep.c
@@ -90,12 +90,12 @@ pyeep_get_channel_label(PyObject* self, PyObject* args) {
     return NULL;
   }
 
-  const char* unit_str = libeep_get_channel_label(handle, index);
-  if (unit_str == NULL) {
+  const char* label_str = libeep_get_channel_label(handle, index);
+  if (label_str == NULL) {
       Py_RETURN_NONE;
   }
 
-  return Py_BuildValue("y", unit_str);
+  return Py_BuildValue("y", label_str);
 }
 ///////////////////////////////////////////////////////////////////////////////
 static
@@ -108,12 +108,12 @@ pyeep_get_channel_status(PyObject* self, PyObject* args) {
     return NULL;
   }
 
-  const char* unit_str = libeep_get_channel_status(handle, index);
-  if (unit_str == NULL) {
+  const char* status_str = libeep_get_channel_status(handle, index);
+  if (status_str == NULL) {
       Py_RETURN_NONE;
   }
 
-  return Py_BuildValue("y", unit_str);
+  return Py_BuildValue("y", status_str);
 }
 ///////////////////////////////////////////////////////////////////////////////
 static
@@ -125,12 +125,12 @@ pyeep_get_channel_type(PyObject* self, PyObject* args) {
   if(!PyArg_ParseTuple(args, "ii", & handle, & index)) {
     return NULL;
   }
-  const char* unit_str = libeep_get_channel_type(handle, index);
-  if (unit_str == NULL) {
+  const char* type_str = libeep_get_channel_type(handle, index);
+  if (type_str == NULL) {
       Py_RETURN_NONE;
   }
 
-  return Py_BuildValue("y", unit_str);
+  return Py_BuildValue("y", type_str);
 }
 ///////////////////////////////////////////////////////////////////////////////
 static
@@ -161,12 +161,12 @@ pyeep_get_channel_reference(PyObject* self, PyObject* args) {
     return NULL;
   }
 
-  const char* unit_str = libeep_get_channel_reference(handle, index);
-  if (unit_str == NULL) {
+  const char* ref_str = libeep_get_channel_reference(handle, index);
+  if (ref_str == NULL) {
       Py_RETURN_NONE;
   }
 
-  return Py_BuildValue("y", unit_str);
+  return Py_BuildValue("y", ref_str);
 }
 ///////////////////////////////////////////////////////////////////////////////
 static
@@ -339,7 +339,12 @@ pyeep_get_hospital(PyObject* self, PyObject* args) {
     return NULL;
   }
 
-  return Py_BuildValue("s", libeep_get_hospital(handle));
+  const char* hospital_str = libeep_get_hospital(handle);
+  if (hospital_str == NULL) {
+      Py_RETURN_NONE;
+  }
+
+  return Py_BuildValue("y", hospital_str);
 }
 ///////////////////////////////////////////////////////////////////////////////
 static
@@ -351,7 +356,12 @@ pyeep_get_machine_make(PyObject* self, PyObject* args) {
     return NULL;
   }
 
-  return Py_BuildValue("s", libeep_get_machine_make(handle));
+  const char* mmake_str = libeep_get_machine_make(handle);
+  if (mmake_str == NULL) {
+      Py_RETURN_NONE;
+  }
+
+  return Py_BuildValue("y", mmake_str);
 }
 ///////////////////////////////////////////////////////////////////////////////
 static
@@ -363,7 +373,12 @@ pyeep_get_machine_model(PyObject* self, PyObject* args) {
     return NULL;
   }
 
-  return Py_BuildValue("s", libeep_get_machine_model(handle));
+  const char* model_str = libeep_get_machine_model(handle);
+  if (model_str == NULL) {
+      Py_RETURN_NONE;
+  }
+
+  return Py_BuildValue("y", model_str);
 }
 ///////////////////////////////////////////////////////////////////////////////
 static
@@ -375,7 +390,12 @@ pyeep_get_machine_serial_number(PyObject* self, PyObject* args) {
     return NULL;
   }
 
-  return Py_BuildValue("s", libeep_get_machine_serial_number(handle));
+  const char* sn_str = libeep_get_machine_serial_number(handle);
+  if (sn_str == NULL) {
+      Py_RETURN_NONE;
+  }
+
+  return Py_BuildValue("y", sn_str);
 }
 ///////////////////////////////////////////////////////////////////////////////
 static

--- a/src/libeep/python/pyeep.c
+++ b/src/libeep/python/pyeep.c
@@ -90,7 +90,12 @@ pyeep_get_channel_label(PyObject* self, PyObject* args) {
     return NULL;
   }
 
-  return Py_BuildValue("s", libeep_get_channel_label(handle, index));
+  const char* unit_str = libeep_get_channel_label(handle, index);
+  if (unit_str == NULL) {
+      Py_RETURN_NONE;
+  }
+
+  return Py_BuildValue("y", unit_str);
 }
 ///////////////////////////////////////////////////////////////////////////////
 static
@@ -103,7 +108,12 @@ pyeep_get_channel_status(PyObject* self, PyObject* args) {
     return NULL;
   }
 
-  return Py_BuildValue("s", libeep_get_channel_status(handle, index));
+  const char* unit_str = libeep_get_channel_status(handle, index);
+  if (unit_str == NULL) {
+      Py_RETURN_NONE;
+  }
+
+  return Py_BuildValue("y", unit_str);
 }
 ///////////////////////////////////////////////////////////////////////////////
 static
@@ -115,8 +125,12 @@ pyeep_get_channel_type(PyObject* self, PyObject* args) {
   if(!PyArg_ParseTuple(args, "ii", & handle, & index)) {
     return NULL;
   }
+  const char* unit_str = libeep_get_channel_type(handle, index);
+  if (unit_str == NULL) {
+      Py_RETURN_NONE;
+  }
 
-  return Py_BuildValue("s", libeep_get_channel_type(handle, index));
+  return Py_BuildValue("y", unit_str);
 }
 ///////////////////////////////////////////////////////////////////////////////
 static
@@ -147,7 +161,12 @@ pyeep_get_channel_reference(PyObject* self, PyObject* args) {
     return NULL;
   }
 
-  return Py_BuildValue("s", libeep_get_channel_reference(handle, index));
+  const char* unit_str = libeep_get_channel_reference(handle, index);
+  if (unit_str == NULL) {
+      Py_RETURN_NONE;
+  }
+
+  return Py_BuildValue("y", unit_str);
 }
 ///////////////////////////////////////////////////////////////////////////////
 static

--- a/tests/libeep/test_libeep.py
+++ b/tests/libeep/test_libeep.py
@@ -166,7 +166,7 @@ def test_get_patient_information(dataset, birthday_format, request):
     """Test reading the patient information."""
     dataset = request.getfixturevalue(dataset)
     cnt = read_cnt(dataset["cnt"]["short"])
-    name, patient_id, sex, birthday = cnt.get_patient_info()
+    name, patient_id, sex, birthday = cnt.get_patient_info(encoding="latin-1")
     assert name == dataset["patient_info"]["name"]
     assert patient_id == dataset["patient_info"]["id"]
     assert sex == dataset["patient_info"]["sex"]

--- a/tests/libeep/test_libeep.py
+++ b/tests/libeep/test_libeep.py
@@ -28,7 +28,7 @@ def test_get_channel_information(dataset, read_raw_bv, request):
     assert cnt.get_sample_frequency() == dataset["sfreq"]
     raw = read_raw_bv(dataset["bv"]["short"])
     for k in range(dataset["n_channels"]):
-        label, unit, ref, status, ch_type = cnt.get_channel(k)
+        label, unit, ref, status, ch_type = cnt.get_channel(k, encoding="latin-1")
         assert label == raw.ch_names[k]
         assert unit.lower() == dataset["ch_unit"]
         if dataset["ch_ref"] is not None:
@@ -44,7 +44,7 @@ def test_get_channel_information_custom_reference(ca_208_refs, read_raw_bv):
     assert cnt.get_sample_frequency() == ca_208_refs["sfreq"]
     raw = read_raw_bv(ca_208_refs["bv"]["short"])
     for k in range(ca_208_refs["n_channels"]):
-        label, unit, ref, status, ch_type = cnt.get_channel(k)
+        label, unit, ref, status, ch_type = cnt.get_channel(k, encoding="latin-1")
         assert label == raw.ch_names[k]
         assert unit.lower() == ca_208_refs["ch_unit"]
         assert status == ""
@@ -65,12 +65,12 @@ def test_get_invalid_channel(dataset, request):
     n_channels = cnt.get_channel_count()
     assert n_channels == dataset["n_channels"] + dataset["n_bips"]
     with pytest.raises(RuntimeError, match="exceeds total channel count"):
-        cnt.get_channel(n_channels + 1)
+        cnt.get_channel(n_channels + 1, encoding="latin-1")
     with pytest.raises(RuntimeError, match="exceeds total channel count"):
-        cnt.get_channel(n_channels)
+        cnt.get_channel(n_channels, encoding="latin-1")
     with pytest.raises(RuntimeError, match="cannot be negative"):
-        cnt.get_channel(-1)
-    info = cnt.get_channel(n_channels - 1)
+        cnt.get_channel(-1, encoding="latin-1")
+    info = cnt.get_channel(n_channels - 1, encoding="latin-1")
     assert isinstance(info, tuple)
     assert len(info) != 0
 
@@ -179,7 +179,7 @@ def test_get_hospital_field(dataset, request):
     """Test getting the hospital field."""
     dataset = request.getfixturevalue(dataset)
     cnt = read_cnt(dataset["cnt"]["short"])
-    assert cnt.get_hospital() == dataset["hospital"]
+    assert cnt.get_hospital(encoding="latin-1") == dataset["hospital"]
 
 
 @pytest.mark.parametrize("dataset", DATASETS)
@@ -188,7 +188,7 @@ def test_get_machine_information(dataset, request):
     dataset = request.getfixturevalue(dataset)
     cnt = read_cnt(dataset["cnt"]["short"])
     # TODO: Investigate why the serial number is missing in both datasets.
-    assert cnt.get_machine_info() == dataset["machine_info"]
+    assert cnt.get_machine_info(encoding="latin-1") == dataset["machine_info"]
 
 
 @pytest.mark.parametrize("dataset", ["andy_101", "ca_208"])


### PR DESCRIPTION
Closes #34 

The discussion with ANT wasn't very productive, my interlocutor was not getting the question/issue.
I think that:
- ANT uses the encoding of the system on which the recording is done, e.g. `Windows-1252`.
- ANT does not cover the edge case of recording with one encoding and then reloading in a different one, i.e. they don't store the encoding format in the CNT file.