### PR TITLE
TST: restore intel mac

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-15-intel, macos-latest]
     name: build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     defaults:
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-15-intel, macos-latest]
         python: ["3.11", "3.13"]
         include:
           - os: ubuntu-latest


### PR DESCRIPTION
This adds a `macos-15-intel` runner. The previous Intel Mac runner was removed in 53b7f56 . If the tests pass, maybe we can publish a wheel for Intel Macs, for folks like me!