### PR TITLE
FIX: Names

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,6 +1,6 @@
 changelog:
   exclude:
     authors:
-      - dependabot
-      - pre-commit-ci
-      - github-actions
+      - dependabot[bot]
+      - pre-commit-ci[bot]
+      - github-actions[bot]


### PR DESCRIPTION
I went to cut a release and there were a bunch of bot names in there. I think tehy just need the `[bot]` added